### PR TITLE
Add note that only 1 Event gets a waveform

### DIFF
--- a/streamlit-app.py
+++ b/streamlit-app.py
@@ -141,6 +141,7 @@ with onedim:
 
 with waveform:
     st.markdown("### Making waveform for Event 1: {0}".format(ev1))
+    st.markdown("This app only creates waveforms for one event (Event 1) to reduce run time.")
 
     try:
         make_waveform(ev1, datadict)


### PR DESCRIPTION
Ticket #54 asks for a note to clarify that only 1 event gets a waveform.  This PR makes that change.  