### PR TITLE
Use GET request to set default events

### DIFF
--- a/peutils.py
+++ b/peutils.py
@@ -173,6 +173,34 @@ def get_pe_url(event):
                     return peinfo['data_url'], peinfo['waveform_family']
 
 
+# -- Check for get parameters
+def get_getparams(eventlist, eventlist2):
+    getparam = st.experimental_get_query_params()
+
+    startindex1 = 0
+    if 'event1' in getparam:
+        event1 = getparam['event1'][0]
+        if event1 in eventlist:
+            startindex1 = eventlist.index(event1)
+            
+    startindex2 = 0
+    if 'event2' in getparam:
+        event2 = getparam['event2'][0]
+        if event2 in eventlist2:
+            startindex2 = eventlist2.index(event2)
+
+    startindex3 = 0
+    if 'event3' in getparam:
+        event3 = getparam['event3'][0]
+        if event3 in eventlist2:
+            startindex3 = eventlist2.index(event3)
+
+    return startindex1, startindex2, startindex3
+
+
+
+
+
 if __name__ == '__main__':
     get_pe_url('cow')
     #print(get_pe_url('GW150914'))

--- a/peutils.py
+++ b/peutils.py
@@ -173,33 +173,25 @@ def get_pe_url(event):
                     return peinfo['data_url'], peinfo['waveform_family']
 
 
-# -- Check for get parameters
+# -- Set the default event choice to any events in the GET request
+# -- Use keys event1, event2, event3.  Default to 0 if key not found.
 def get_getparams(eventlist, eventlist2):
     getparam = st.experimental_get_query_params()
 
-    startindex1 = 0
-    if 'event1' in getparam:
-        event1 = getparam['event1'][0]
-        if event1 in eventlist:
-            startindex1 = eventlist.index(event1)
-            
-    startindex2 = 0
-    if 'event2' in getparam:
-        event2 = getparam['event2'][0]
-        if event2 in eventlist2:
-            startindex2 = eventlist2.index(event2)
+    indexlist = []
+    for key in ['event1', 'event2', 'event3']:
+        startindex = 0
+        if key in getparam:
+            event = getparam[key][0]
+            if event in eventlist:
+                if key=='event1':
+                    startindex = eventlist.index(event)
+                else:
+                    startindex = eventlist2.index(event)
 
-    startindex3 = 0
-    if 'event3' in getparam:
-        event3 = getparam['event3'][0]
-        if event3 in eventlist2:
-            startindex3 = eventlist2.index(event3)
-
-    return startindex1, startindex2, startindex3
-
-
-
-
+        indexlist.append(startindex)
+    st.text(indexlist)
+    return indexlist
 
 if __name__ == '__main__':
     get_pe_url('cow')

--- a/peutils.py
+++ b/peutils.py
@@ -173,8 +173,9 @@ def get_pe_url(event):
                     return peinfo['data_url'], peinfo['waveform_family']
 
 
-# -- Set the default event choice to any events in the GET request
-# -- Use keys event1, event2, event3.  Default to 0 if key not found.
+# -- Set the default event choice index to any events in the GET request
+# -- Use keys event1, event2, event3.
+# -- Default to 0 for any key not found.
 def get_getparams(eventlist, eventlist2):
     getparam = st.experimental_get_query_params()
 
@@ -190,7 +191,6 @@ def get_getparams(eventlist, eventlist2):
                     startindex = eventlist2.index(event)
 
         indexlist.append(startindex)
-    st.text(indexlist)
     return indexlist
 
 if __name__ == '__main__':

--- a/streamlit-app.py
+++ b/streamlit-app.py
@@ -32,6 +32,15 @@ eventlist = get_eventlist(catalog=['GWTC-3-confident', 'GWTC-2.1-confident', 'GW
 eventlist2 = deepcopy(eventlist)
 eventlist2.insert(0,None)  
 
+# -- Check for any get params
+getparam = st.experimental_get_query_params()
+startindex = 0
+if 'event1' in getparam:
+    event1 = getparam['event1'][0]
+    if event1 in eventlist:
+        startindex = eventlist.index(event1)
+
+
 # -- Helper method to get list of events
 def get_event_list():
     x = [st.session_state['ev1'], 
@@ -54,7 +63,7 @@ def update_pe():
 with st.sidebar:
     with st.form("event_selection"):
         st.markdown("### Select events")
-        ev1 = st.selectbox('Event 1', eventlist,  key='ev1')
+        ev1 = st.selectbox('Event 1', eventlist,  key='ev1', index=startindex)
         ev2 = st.selectbox('Event 2', eventlist2,  key='ev2')    
         ev3 = st.selectbox('Event 3', eventlist2,  key='ev3')
         submitted = st.form_submit_button("Update data", on_click=update_pe)

--- a/streamlit-app.py
+++ b/streamlit-app.py
@@ -35,14 +35,6 @@ eventlist2.insert(0,None)
 # -- Check for any get params
 startindex1, startindex2, startindex3 = get_getparams(eventlist,eventlist2)
 
-#getparam = st.experimental_get_query_params()
-#startindex = 0
-#if 'event1' in getparam:
-#    event1 = getparam['event1'][0]
-#    if event1 in eventlist:
-#        startindex = eventlist.index(event1)
-
-
 # -- Helper method to get list of events
 def get_event_list():
     x = [st.session_state['ev1'], 

--- a/streamlit-app.py
+++ b/streamlit-app.py
@@ -33,12 +33,14 @@ eventlist2 = deepcopy(eventlist)
 eventlist2.insert(0,None)  
 
 # -- Check for any get params
-getparam = st.experimental_get_query_params()
-startindex = 0
-if 'event1' in getparam:
-    event1 = getparam['event1'][0]
-    if event1 in eventlist:
-        startindex = eventlist.index(event1)
+startindex1, startindex2, startindex3 = get_getparams(eventlist,eventlist2)
+
+#getparam = st.experimental_get_query_params()
+#startindex = 0
+#if 'event1' in getparam:
+#    event1 = getparam['event1'][0]
+#    if event1 in eventlist:
+#        startindex = eventlist.index(event1)
 
 
 # -- Helper method to get list of events
@@ -63,9 +65,9 @@ def update_pe():
 with st.sidebar:
     with st.form("event_selection"):
         st.markdown("### Select events")
-        ev1 = st.selectbox('Event 1', eventlist,  key='ev1', index=startindex)
-        ev2 = st.selectbox('Event 2', eventlist2,  key='ev2')    
-        ev3 = st.selectbox('Event 3', eventlist2,  key='ev3')
+        ev1 = st.selectbox('Event 1', eventlist,  key='ev1', index=startindex1)
+        ev2 = st.selectbox('Event 2', eventlist2,  key='ev2', index=startindex2)    
+        ev3 = st.selectbox('Event 3', eventlist2,  key='ev3', index=startindex3)
         submitted = st.form_submit_button("Update data", on_click=update_pe)
 
 chosenlist = get_event_list()

--- a/streamlit-app.py
+++ b/streamlit-app.py
@@ -97,6 +97,13 @@ with about:
 if 'datadict' not in st.session_state:
     update_pe()
 
+
+# -- Add share info
+with about:
+    st.markdown("## Share this page")
+    st.markdown(":link: [Link to share these plots](/?event1={0}&event2={1}&event3={2})".format(ev1, ev2, ev3)) 
+
+
 # -- Short-cut variable names
 datadict = st.session_state['datadict']
 published_dict = st.session_state['published_dict']


### PR DESCRIPTION
App now looks for the keys `event1`, `event2`, and `event3` in GET request.  Selects these events by default if found.

Also added a sharing link to share page with selected events. 