### PR TITLE
display config info before making plots

### DIFF
--- a/streamlit-app.py
+++ b/streamlit-app.py
@@ -99,11 +99,46 @@ with about:
     st.markdown("## Share this page")
     st.markdown(":link: [Link to share these plots](/?event1={0}&event2={1}&event3={2})".format(ev1, ev2, ev3)) 
 
+# ------------------------
+# -- Dispaly config options
+# -----------------------
+with config:
+
+    # -- Check cache status
+    homedir = os.path.expanduser('~')
+    cachelist = glob.glob(homedir + '/.streamlit/cache/*.memo')
+    cachesize = len(cachelist)
+    cachepercent = int(cachesize / len(eventlist) * 100)
+    st.metric('Cache Size:', '{0}%'.format(cachepercent))
+
+    st.write("## Build Cache")
+    st.write("""This app uses a local cache to store data downloaded from zenodo.  The cache is designed to 
+            build up over time as the app is used, or the cache may be built on-demand.  This process could take
+            up to several hours, but may improve app performance after it is complete.""")
+
+    if cachepercent < 99:
+        st.button('Build Cache', on_click=stockcache, args=[eventlist], type='primary')
+    else:
+        st.write("Cache is complete!")
+    
+    st.write("## Clear Cache")
+    st.write("""Clearing the cache will force the app
+       to download samples directly from zenodo.
+       This may slow down the app.""")
+
+    with st.expander('Clear Cache'):
+        st.warning("WARNING: Clearing the cache will slow down the app for all users.", icon="⚠️")
+        if st.button("Clear Cache", type='primary'):
+            st.cache_data.clear()
+
 
 # -- Short-cut variable names
 datadict = st.session_state['datadict']
 published_dict = st.session_state['published_dict']
 
+# --------------
+# Display plots
+# --------------
 with twodim:
     st.markdown("""
         * These 2-D plots can reveal correlations between parameters.  
@@ -167,34 +202,6 @@ with waveform:
         st.write("Unable to generate maximum likelihood waveform.  Making approximate waveform instead.")
         simple_plot_waveform(ev1)
     
-with config:
-
-    # -- Check cache status
-    homedir = os.path.expanduser('~')
-    cachelist = glob.glob(homedir + '/.streamlit/cache/*.memo')
-    cachesize = len(cachelist)
-    cachepercent = int(cachesize / len(eventlist) * 100)
-    st.metric('Cache Size:', '{0}%'.format(cachepercent))
-
-    st.write("## Build Cache")
-    st.write("""This app uses a local cache to store data downloaded from zenodo.  The cache is designed to 
-            build up over time as the app is used, or the cache may be built on-demand.  This process could take
-            up to several hours, but may improve app performance after it is complete.""")
-
-    if cachepercent < 99:
-        st.button('Build Cache', on_click=stockcache, args=[eventlist], type='primary')
-    else:
-        st.write("Cache is complete!")
-    
-    st.write("## Clear Cache")
-    st.write("""Clearing the cache will force the app
-       to download samples directly from zenodo.
-       This may slow down the app.""")
-
-    with st.expander('Clear Cache'):
-        st.warning("WARNING: Clearing the cache will slow down the app for all users.", icon="⚠️")
-        if st.button("Clear Cache", type='primary'):
-            st.cache_data.clear()
 
 
     


### PR DESCRIPTION
Display config info before making plots, in hopes that this allows clearing the cache even when an error occurs.