### PR TITLE
Improve 1-d plot style

### DIFF
--- a/makealtair.py
+++ b/makealtair.py
@@ -16,7 +16,6 @@ from gwosc import datasets
 from peutils import *
 import pesummary
 from peutils import *
-from pesummary.gw.plots.latex_labels import GWlatex_labels
 
 def get_params_intersect(sample_dict, chosenlist):
     allparams = set(sample_dict[chosenlist[0]].parameters)

--- a/makealtair.py
+++ b/makealtair.py
@@ -16,7 +16,7 @@ from gwosc import datasets
 from peutils import *
 import pesummary
 from peutils import *
-
+from pesummary.gw.plots.latex_labels import GWlatex_labels
 
 def get_params_intersect(sample_dict, chosenlist):
     allparams = set(sample_dict[chosenlist[0]].parameters)
@@ -65,18 +65,13 @@ def make_altair_plots(chosenlist, sample_dict):
             if event is None: continue
 
             samples = sample_dict[event]
-
-            # -- Explore parameters
-            # st.markdown(samples.all_latex_labels[param])
-            #st.text(samples.parameters[0])
-            #st.text(dir(samples[param]))
             
             # -- Make histogram
             value, bins = np.histogram(samples[param], bins=50, density=True)
-
+            
             source = pd.DataFrame({
-                param: bins[1:],
-                'density': value,
+                param : bins[1:],
+                'Probability Density': value,
                 'Event': len(value)*[event]
             })
 
@@ -85,7 +80,7 @@ def make_altair_plots(chosenlist, sample_dict):
                 interpolate='step',
             ).encode(
                 alt.X(param),
-                alt.Y('density'),
+                alt.Y('Probability Density'),
                 color='Event:N')
 
             chartlist.append(chart)
@@ -95,16 +90,16 @@ def make_altair_plots(chosenlist, sample_dict):
             allchart+=chart
 
         # -- Def
-        refurl = 'https://lscsoft.docs.ligo.org/pesummary/stable_docs/gw/parameters.html#:~:text={0}'.format(param)
+        refurl = 'https://lscsoft.docs.ligo.org/pesummary/reference/gw/parameters.html#:~:text={0}'.format(param)
 
         unitlabel = samples.all_latex_labels[param]
         
         #st.altair_chart(allchart, use_container_width=True)
         if (count % 2):
-            col2.markdown("#### {2} - [{0}]({1})".format(param, refurl, unitlabel))
+            col2.markdown("### [{1}]({0})".format(refurl, unitlabel))
             col2.altair_chart(allchart, use_container_width=True)
         else:
-            col1.markdown("#### {2} - [{0}]({1})".format(param, refurl, unitlabel))
+            col1.markdown("### [{1}]({0})".format(refurl, unitlabel))
             col1.altair_chart(allchart, use_container_width=True)
 
     # unravel the histogram


### PR DESCRIPTION
I tried to add fancy latex labels to the x-axis of the 1-D plots.

This does not seem to be possible, as the plot library (Altair) does not support latex at this time, as best I can tell.
Instead, I changed the label above each plot, to better emphasize the latex label there.  

In addition, I changed the y-axis to say "Probability Density" instead of `density`, to match the `pesummary` convention.