### PR TITLE
Try to fix GWTC-1 skymap bug

### DIFF
--- a/peutils.py
+++ b/peutils.py
@@ -92,7 +92,6 @@ def make_datadict(chosenlist):
 def load_samples(event, gwtc=True):
     if gwtc:
         url, waveform = get_pe_url(event)
-        st.text(url)
         
     if event != 'GW170817':
         r = requests.get(url)

--- a/peutils.py
+++ b/peutils.py
@@ -92,14 +92,15 @@ def make_datadict(chosenlist):
 def load_samples(event, gwtc=True):
     if gwtc:
         url, waveform = get_pe_url(event)
-
-    try: 
+        st.text(url)
+        
+    if event != 'GW170817':
         r = requests.get(url)
         tfile = tempfile.NamedTemporaryFile(suffix='.h5')
         tfile.write(r.content)
         samples = read(tfile.name, disable_prior=True)
-        
-    except:
+    else:
+        # Use GWTC-1 samples for only GW170817
         url = 'https://dcc.ligo.org/public/0157/P1800370/005/{0}_GWTC-1.hdf5'.format(event)
         r = requests.get(url)
         tfile = tempfile.NamedTemporaryFile(suffix='.h5')


### PR DESCRIPTION
* The app had a try/except that would default to GWTC-1 if the download failed
* This is bad behavior, because downloads sometimes fail (e.g. if zenodo is too slow), and then you get the wrong GWTC-1 files from the DCC instead of the GWTC-2.1 files
* This unexpected behavior would cause the skymaps to fail, which throws an error
* This bug fix removes the try/except, and instead explicitly only gets the GW170817 files from the GWTC-1 repo, since there is no GWTC-2.1 version of this event.