### PR TITLE
Adding GWTC-4.1 events

### DIFF
--- a/pe-viewer/peutils.py
+++ b/pe-viewer/peutils.py
@@ -30,7 +30,7 @@ lock = threading.RLock()
 
 # -- Set pelican parameters
 pelicandict = {
-    'GWTC-4.0': (2025,17014085),
+    'GWTC-4.1': (2026, 20275769),
     'GWTC-3-confident': (2023, 8177023),
     'GWTC-2.1-confident': (2022, 6513631),
     'GWTC-1-confident': (000, 000)

--- a/pe-viewer/streamlit-app.py
+++ b/pe-viewer/streamlit-app.py
@@ -33,7 +33,7 @@ st.markdown("""Make plots of waveforms, source parameters, and skymaps for gravi
 st.image('img/black-hole-ellipse.png')
 
 # -- Query GWOSC for GWTC events
-eventlist = get_eventlist(catalog=['GWTC-4.0', 'GWTC-3-confident', 'GWTC-2.1-confident', 'GWTC-1-confident'],
+eventlist = get_eventlist(catalog=['GWTC-4.1', 'GWTC-3-confident', 'GWTC-2.1-confident', 'GWTC-1-confident'],
                           optional=False)
 
 # -- 2nd and 3rd events are optional, so include "None" option


### PR DESCRIPTION
The Event Portal was updated with GWTC 4.1 events replacing GWTC 4.0 events. This MR updates the Event Viewer to include the GWTC-4.1 events.